### PR TITLE
Try to dlopen .so.0 instead of .so

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -409,11 +409,11 @@ static void onDispose(GObject *pObject)
 
 static void indicator_keyboard_service_init(IndicatorKeyboardService *self)
 {
-    gchar *sLib = "libayatana-keyboard-x11.so";
+    gchar *sLib = "libayatana-keyboard-x11.so.0";
 
     if (ayatana_common_utils_is_lomiri())
     {
-        sLib = "libayatana-keyboard-lomiri.so";
+        sLib = "libayatana-keyboard-lomiri.so.0";
     }
 
     m_pLibHandle = dlopen(sLib, RTLD_NOW);


### PR DESCRIPTION
Some distributions do not provide a .so symlink in the default package,
and in case there are major breaking changes (.so.1) then the code
likely needs to get adjusted anyways.

--

Somewhat based on this stackoverflow answer https://stackoverflow.com/questions/2827181/dynamic-loading-of-shared-objects-using-dlopen