### PR TITLE
Try to place the indicator in the leftmost position by default

### DIFF
--- a/data/org.ayatana.indicator.keyboard
+++ b/data/org.ayatana.indicator.keyboard
@@ -1,11 +1,10 @@
 [Indicator Service]
 Name=ayatana-indicator-keyboard
 ObjectPath=/org/ayatana/indicator/keyboard
-Position=-10
+Position=110
 
 [phone]
 ObjectPath=/org/ayatana/indicator/keyboard/phone
-Position=1000
 
 [desktop]
 ObjectPath=/org/ayatana/indicator/keyboard/desktop


### PR DESCRIPTION
This seems to have been the intention in commit
d2758a873a848fc4113a4087d53446f73c6543cb.