### PR TITLE
Rebuild display and settings sections on hardware keyboard state change

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -422,7 +422,7 @@ static void onLayoutChanged(Keyboard *pKeyboard, gpointer pData)
 static void onConfigChanged(Keyboard *pKeyboard, gpointer pData)
 {
     IndicatorKeyboardService *self = INDICATOR_KEYBOARD_SERVICE(pData);
-    rebuildNow(self, SECTION_LAYOUTS);
+    rebuildNow(self, SECTION_LAYOUTS | SECTION_DISPLAY | SECTION_SETTINGS);
 }
 
 static void onLayoutSelected(GSimpleAction *pAction, GVariant *pVariant, gpointer pData)


### PR DESCRIPTION
onConfigChanged only rebuilt SECTION_LAYOUTS, leaving "Show Current Layout" and "Keyboard Settings" stale when a keyboard was connected or disconnected at runtime.