### PR TITLE
Disable display section on Lomiri

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          ayatana-indicator-common,
-         matekbd-keyboard-display | gkbd-capplet | tecla,
+Recommends: matekbd-keyboard-display | gkbd-capplet | tecla,
 Description: Ayatana Indicator Keyboard Applet
  This package contains the keyboard indicator, which should show as an
  icon in the top panel of indicator aware destkop environments.

--- a/src/service.c
+++ b/src/service.c
@@ -289,12 +289,13 @@ static GMenuModel* createDisplaySection (IndicatorKeyboardService *self)
 
     if (self->pPrivate->bLomiri)
     {
-        gboolean bHardwareKeyboard = m_fnKeyboardHasHardwareKeyboard (self->pPrivate->pKeyboard);
-
-        if (!bHardwareKeyboard)
-        {
-            bDisplay = FALSE;
-        }
+#if 0
+        /* Re-enable when a native Qt/Lomiri keyboard layout viewer is available.
+         * tecla (GTK4) does not work well on Lomiri */
+        bDisplay = m_fnKeyboardHasHardwareKeyboard (self->pPrivate->pKeyboard);
+#else
+        bDisplay = FALSE;
+#endif
     }
 
     if (bDisplay)
@@ -474,9 +475,12 @@ static void onDisplay (GSimpleAction *pAction, GVariant *pVariant, gpointer pDat
     }
     else if (bLomiri)
     {
-
+#if 0
+        /* Re-enable when a native Qt/Lomiri keyboard layout viewer is available.
+         * tecla (GTK4) does not work on Mir 1.x. */
         sProgram = "tecla";
         m_fnKeyboardGetLayout (self->pPrivate->pKeyboard, HWKBD, -1, NULL, NULL, &sArgs);
+#endif
     }
     else
     {


### PR DESCRIPTION
No suitable native keyboard layout viewer exists for Lomiri/Ubuntu Touch:
tecla (GTK4) does not work well on Lomiri, and the feature is too
niche to justify the dependency on a mobile platform.

The Lomiri code paths are wrapped in #if 0 for when a native Qt/Lomiri
keyboard layout viewer becomes available. On non-Lomiri desktops the
feature is unchanged.