### PR TITLE
src/keyboard-lomiri.c: Show OSK layouts also if no hardware keyboard …

### DIFF
--- a/src/keyboard-lomiri.c
+++ b/src/keyboard-lomiri.c
@@ -693,7 +693,7 @@ gboolean keyboard_hasHardwareKeyboard (Keyboard *self)
 
 gboolean keyboard_hasSoftwareKeyboard (Keyboard *self)
 {
-    return self->pPrivate->bSoftwareKeyboard;
+    return ((!self->pPrivate->bHardwareKeyboard) | self->pPrivate->bSoftwareKeyboard);
 }
 
 static void keyboard_init(Keyboard *self)


### PR DESCRIPTION
…is present

Previous behaviour: OSK layouts got only shown if 'always-show-osk' gsettings was set to TRUE.